### PR TITLE
fix: Remove docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ Let's do it!
 ## Required Software
 
 - [Docker](https://docs.docker.com/get-docker/)
-- [Docker Compose](https://docs.docker.com/compose/install/) (comes bundled with Docker Desktop)
 
 ## Recommended Hardware
 


### PR DESCRIPTION
It comes with both the desktop version and the CLI version.