### PR TITLE
fix: clean up grafana datasources

### DIFF
--- a/docker/grafana/dashboards/simple_node_dashboard.json
+++ b/docker/grafana/dashboards/simple_node_dashboard.json
@@ -134,7 +134,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "T7Dj-Zr7z"
+            "uid": "6R74VAnVz"
           },
           "editorMode": "code",
           "expr": "fault_detector_highest_checked_batch_index{}",
@@ -145,7 +145,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "T7Dj-Zr7z"
+            "uid": "6R74VAnVz"
           },
           "editorMode": "code",
           "expr": "fault_detector_highest_known_batch_index{}",
@@ -354,7 +354,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "T7Dj-Zr7z"
+            "uid": "6R74VAnVz"
           },
           "editorMode": "code",
           "exemplar": true,
@@ -368,7 +368,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "T7Dj-Zr7z"
+            "uid": "6R74VAnVz"
           },
           "exemplar": true,
           "expr": "healthcheck_is_currently_diverged",
@@ -545,7 +545,7 @@
         {
           "datasource": {
             "type": "prometheus",
-            "uid": "T7Dj-Zr7z"
+            "uid": "6R74VAnVz"
           },
           "editorMode": "code",
           "expr": "data_transport_layer_highest_synced_l1_block{}",

--- a/docker/grafana/provisioning/datasources/all.yml
+++ b/docker/grafana/provisioning/datasources/all.yml
@@ -1,19 +1,26 @@
+apiVersion: 1
+
+deleteDatasources:
+- name: 'Prometheus'
+- name: 'InfluxDB'
+
 datasources:
--  access: 'proxy'
-   editable: true
-   is_default: true
-   name: 'Prometheus'
-   uid: 'T7Dj-Zr7z'
-   org_id: 1
-   type: 'prometheus'
-   url: 'http://prometheus:9090'
-   version: 1
--  access: 'proxy'
-   editable: true
-   is_default: false
-   name: 'InfluxDB'
-   org_id: 1
-   type: 'influxdb'
-   database: 'l2geth'
-   url: 'http://influxdb:8086'
-   version: 1
+- access: 'proxy'
+  editable: true
+  is_default: true
+  name: 'Prometheus'
+  uid: '6R74VAnVz'
+  org_id: 1
+  type: 'prometheus'
+  url: 'http://prometheus:9090'
+  version: 1
+- access: 'proxy'
+  editable: true
+  is_default: false
+  name: 'InfluxDB'
+  uid: '4knV40nVz'
+  org_id: 1
+  type: 'influxdb'
+  database: 'l2geth'
+  url: 'http://influxdb:8086'
+  version: 1


### PR DESCRIPTION
Cleans up the grafana datasources yml file. Importantly deletes the datasources and re-initializes them whenever grafana is restarted to avoid issues where dashboard shows up empty.