### PR TITLE
Update op-node image to v1.0.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,7 +99,7 @@ services:
     <<: *logging
 
   op-node:
-    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v0.10.9
+    image: us-docker.pkg.dev/oplabs-tools-artifacts/images/op-node:v1.0.0
     restart: unless-stopped
     stop_grace_period: 3m
     entrypoint: /scripts/op-node-start.sh


### PR DESCRIPTION
According to the [op-node latest release](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.0.0), goerli nodes should be updated by March 17th in order to continue working.

I'm assuming the image tag in the docker-compose file should also be update accordingly?