### PR TITLE
fix(readme): explain how to spot corrupted geth

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ docker compose down -v
 Will completely wipe the node by removing the volumes that were created for each container.
 Note that this is a destructive action, be very careful!
 
+You may need to do this if the `op-geth` data directory becomes corrupted because of an unclean shutdown.
+Your `op-geth` data directory is likely corrupted if you see the following error log from the `op-node`:
+
+```
+stage 0 failed resetting: temp: failed to find the L2 Heads to start from: failed to fetch L2 block by hash 0x0000000000000000000000000000000000000000000000000000000000000000
+```
+
 #### Logs
 
 ```sh


### PR DESCRIPTION
Gives a small explainer about how to spot a corrupted op-geth node.