### PR TITLE
l2geth: generate witness file

### DIFF
--- a/envs/mainnet/l2geth.env
+++ b/envs/mainnet/l2geth.env
@@ -15,6 +15,7 @@ ROLLUP_CLIENT_HTTP=http://dtl:7878
 ROLLUP_MAX_CALLDATA_SIZE=40000
 ROLLUP_POLL_INTERVAL_FLAG=1s
 ROLLUP_VERIFIER_ENABLE=true
+L2GETH_STATE_DUMP_PATH=/geth/l2geth-state
 
 ###############################################################################
 #                            ↓ STANDARD OPTIONS ↓                             #


### PR DESCRIPTION
Generates the witness file by setting the required env var. https://github.com/ethereum-optimism/optimism-legacy/blob/efea631cf19d57d3a64374cb81ce545f958bd38f/l2geth/statedumper/dumper.go#L20 Useful for people who want to run the migration