### PR TITLE
Fix lz4 ERROR_contentChecksum_invalid

### DIFF
--- a/docker/dockerfiles/Dockerfile.bedrock-init
+++ b/docker/dockerfiles/Dockerfile.bedrock-init
@@ -14,6 +14,3 @@ RUN cp /usr/local/go/bin/go /usr/bin/go
 RUN curl -L https://foundry.paradigm.xyz | bash
 RUN /root/.foundry/bin/foundryup
 RUN rsync -a /root/.foundry/bin/ /usr/bin/
-
-# Install Python packages.
-RUN pip3 install qbittorrent-api

--- a/docker/dockerfiles/Dockerfile.bedrock-init
+++ b/docker/dockerfiles/Dockerfile.bedrock-init
@@ -1,4 +1,4 @@
-FROM ubuntu:22.04
+FROM ubuntu:23.10
 
 # Disable prompts during package installation.
 ARG DEBIAN_FRONTEND=noninteractive
@@ -7,7 +7,7 @@ ARG DEBIAN_FRONTEND=noninteractive
 RUN apt-get update && apt install -y curl wget git rsync build-essential openssl python3 python3-pip aria2 zstd lz4
 
 # Install Go.
-RUN curl -sSL https://golang.org/dl/go1.19.5.linux-amd64.tar.gz | tar -v -C /usr/local -xz
+RUN curl -sSL https://golang.org/dl/go1.21.6.linux-amd64.tar.gz | tar -v -C /usr/local -xz
 RUN cp /usr/local/go/bin/go /usr/bin/go
 
 # Install Foundry.

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -24,7 +24,7 @@ function extractzst() {
 #   loc: Location to extract to.
 function extractlz4() {
   mkdir -p $2
-  tar --use-compress-program=lz4 -xf $1 -C $2
+  tar --use-compress-program="lz4 --no-crc" -xf $1 -C $2
 }
 
 # download: Downloads a file and provides basic progress percentages.


### PR DESCRIPTION
This fix by upgrading ubuntu to 23.10 which install latest lz4 and pass --no-crc to skip checksum checking

Fixes #118

<img width="1492" alt="image" src="https://github.com/smartcontracts/simple-optimism-node/assets/4103490/d0148ed8-96e0-4461-b2bb-682d6e8483cb">
