### PR TITLE
Fix progress.sh bash intrepeter

### DIFF
--- a/progress.sh
+++ b/progress.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/bin/bash
 
 # Load Environment Variables
 if [ -f .env ]; then


### PR DESCRIPTION
Since mac doesn't have `/usr/bin/bash`, it failed!

Changed to `/bin/bash`