### PR TITLE
Remove force-recreate

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Pull the latest updates from GitHub, and Docker Hub and rebuild the container.
 ```sh
 git pull
 docker compose pull
-docker compose up -d --build --force-recreate
+docker compose up -d --build
 ```
 
 Will upgrade your node with minimal downtime.


### PR DESCRIPTION
https://github.com/ethereum-optimism/developers/discussions/596

It appears that `--force-recreate` is performing a forced shutdown instead of a soft restart, which risks database corruption.

I have tested that using only `--build` is sufficient, as it will softly restart the containers if there is an upgrade.

```
docker compose up -d --build
```