### PR TITLE
progress.sh support for other networks

### DIFF
--- a/progress.sh
+++ b/progress.sh
@@ -14,25 +14,26 @@ CHAIN_ID=`cast chain-id`
 echo Chain ID: $CHAIN_ID
 echo Sampling, please wait
 
-if [ $CHAIN_ID -eq 10 ]; then
-  L2_URL=https://mainnet.optimism.io
-fi
-
-if [ $CHAIN_ID -eq 11155420 ]; then
-  L2_URL=https://sepolia.optimism.io
-fi
-
 T0=`cast block-number --rpc-url $ETH_RPC_URL` ; sleep 10 ; T1=`cast block-number --rpc-url $ETH_RPC_URL`
 PER_MIN=$(($T1 - $T0))
 PER_MIN=$(($PER_MIN * 6))
 echo Blocks per minute: $PER_MIN
-
 
 if [ $PER_MIN -eq 0 ]; then
     echo Not syncing
     exit;
 fi
 
+case $CHAIN_ID in
+  10)       L2_URL=https://mainnet.optimism.io ;;
+  11155420) L2_URL=https://sepolia.optimism.io ;;
+  *)        L2_URL=$HEALTHCHECK__REFERENCE_RPC_PROVIDER ;;
+esac
+
+if [ -z ${L2_URL-} ]; then
+  echo "No L2 RPC service to compare against, won't estimate remaining time"
+  exit
+fi
 
 # How many more blocks do we need?
 HEAD=`cast block-number --rpc-url $L2_URL`


### PR DESCRIPTION
Only OP-mainnet and sepolia are hardcoded. For other networks, use the healthcheck RPC. If that is not set, give an informative message instead of an error.

Refactor: move setting L2_URL down (it's not used earlier) and use a case statement instead of multiple ifs.