### PR TITLE
progress.sh: Avoid accidental early return

### DIFF
--- a/progress.sh
+++ b/progress.sh
@@ -36,9 +36,9 @@ fi
 
 # How many more blocks do we need?
 HEAD=`cast block-number --rpc-url $L2_URL`
-BEHIND=`expr $HEAD - $T1`
-MINUTES=`expr $BEHIND / $PER_MIN`
-HOURS=`expr $MINUTES / 60`
+BEHIND=$((HEAD - T1))
+MINUTES=$((BEHIND / PER_MIN))
+HOURS=$((MINUTES / 60))
 
 if [ $MINUTES -le 60 ] ; then
    echo Minutes until sync completed: $MINUTES


### PR DESCRIPTION
`expr` returns a non-zero exit code if its calculated value is zero. This is surprising and usually not what you want. In this case, it will lead to the script terminating early for some values (e.g. HOURS=0). Small example to show the problem:

```
> bash -c 'HOURS=`expr 0` && echo true || echo false'
false
```

Fortunately, bash has the arithmetic calculation syntax $((...)) that behaves as intended.