### PR TITLE
Upgrade to ubuntu 24

### DIFF
--- a/docker/dockerfiles/Dockerfile.bedrock-init
+++ b/docker/dockerfiles/Dockerfile.bedrock-init
@@ -1,4 +1,4 @@
-FROM ubuntu:23.10
+FROM ubuntu:24.04
 
 # Disable prompts during package installation.
 ARG DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
There is some problem with apt repository on Ubuntu 23. Upgrading to Ubuntu 24

Fix #178 