### PR TITLE
typo fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Open `.env` with your editor of choice
 docker compose up -d --build
 ```
 
-Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background. We recommended to add `--build` to make sure that latest changes are being applied.
+Will start the node in a detached shell (`-d`), meaning the node will continue to run in the background. We recommended to add `--build` to make sure that latest changes are being applied.
 
 ### View logs
 


### PR DESCRIPTION
## Typo Fix in README.md

### Changes Made:
1. Corrected a typo in the `README.md` file:  
   - Changed **"detatched"** to **"detached"** in the sentence:  
     *"Will start the node in a detatched shell (`-d`), meaning the node will continue to run in the background."*

This edit improves the clarity and accuracy of the documentation.
