### PR TITLE
feat(execution): add Nethermind as alternative client

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,6 +8,18 @@ NETWORK_NAME=op-mainnet
 # Type of node to run ("full" or "archive"), note that "archive" is 10x bigger
 NODE_TYPE=full
 
+# Execution client to use ("nethermind" or "op-geth")
+EXECUTION_CLIENT=op-geth
+
+# Nethermind specific settings
+NETHERMIND_DATA_DIR=/nethermind
+NETHERMIND_LOG_LEVEL=Info
+PORT__OP_NETHERMIND_HTTP=9995
+PORT__OP_NETHERMIND_WS=9996
+PORT__OP_NETHERMIND_AUTHRPC=8551
+PORT__OP_NETHERMIND_METRICS=6060
+PORT__OP_NETHERMIND_DISCOVERY=30303
+
 ###############################################################################
 #                            ↓ REQUIRED (BEDROCK) ↓                           #
 ###############################################################################

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ Open `.env` with your editor of choice
 * **NODE_TYPE** - Choose the type of node you want to run:
     * `full` (Full node) - A Full node contains a few recent blocks without historical states.
     * `archive` (Archive node) - An Archive node stores the complete history of the blockchain, including historical states.
+*  **EXECUTION_CLIENT** - Choose which execution client to use:
+    * `op-geth` - The original execution client for OP Stack (default)
+    * `nethermind` - Alternative high-performance execution client written in C#
+    
+    You can set this in your `.env` file or use it as an environment variable when running the `start.sh` script.
 * **OP_NODE__RPC_ENDPOINT** - Specify the endpoint for the RPC of Layer 1 (e.g., Ethereum mainnet). For instance, you can use the free plan of Alchemy for the Ethereum mainnet.
 * **OP_NODE__L1_BEACON** - Specify the beacon endpoint of Layer 1. You can use [QuickNode for the beacon endpoint](https://www.quicknode.com). For example: https://xxx-xxx-xxx.quiknode.pro/db55a3908ba7e4e5756319ffd71ec270b09a7dce
 * **OP_NODE__RPC_TYPE** - Specify the service provider for the RPC endpoint you've chosen in the previous step. The available options are:
@@ -119,15 +124,42 @@ Open `.env` with your editor of choice
 * **IMAGE_TAG__[...]** - Use custom docker image for specified components.
 * **PORT__[...]** - Use custom port for specified components.
 
+### Nethermind Configuration
+When using Nethermind as the execution client, you can configure the following additional settings:
+
+* **NETHERMIND_DATA_DIR** - Directory where Nethermind stores its data (default: /nethermind)
+* **NETHERMIND_LOG_LEVEL** - Logging level for Nethermind (default: Info)
+* **PORT__OP_NETHERMIND_HTTP** - HTTP RPC port (default: 9995)
+* **PORT__OP_NETHERMIND_WS** - WebSocket RPC port (default: 9996)
+* **PORT__OP_NETHERMIND_AUTHRPC** - Engine API port (default: 8551)
+* **PORT__OP_NETHERMIND_METRICS** - Metrics port (default: 6060)
+* **PORT__OP_NETHERMIND_DISCOVERY** - P2P discovery port (default: 30303)
+
 ## Operating the Node
 
 ### Start
 
+You can start the node using the provided `start.sh` script:
+
 ```sh
-docker compose up -d --build
+# Start with op-geth (default)
+./start.sh
+
+# Start with Nethermind
+EXECUTION_CLIENT=nethermind ./start.sh
 ```
 
-Will start the node in a detached shell (`-d`), meaning the node will continue to run in the background. We recommended to add `--build` to make sure that latest changes are being applied.
+Or using docker compose directly:
+
+```sh
+# For op-geth
+docker compose --profile op-geth up -d --build
+
+# For Nethermind
+docker compose --profile nethermind up -d --build
+```
+
+This will start the node in a detached shell (`-d`), meaning the node will continue to run in the background. We recommend adding `--build` to make sure that latest changes are being applied.
 
 ### View logs
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,6 +32,9 @@ services:
     restart: unless-stopped
     stop_grace_period: 5m
     entrypoint: /scripts/start-op-geth.sh
+    profiles: 
+      - op-geth
+      - !nethermind
     env_file:
       - ./envs/${NETWORK_NAME}/op-geth.env
       - .env
@@ -46,6 +49,34 @@ services:
       - ${PORT__OP_GETH_WS:-9994}:8546
       - ${PORT__OP_GETH_P2P:-39393}:${PORT__OP_GETH_P2P:-39393}/udp
       - ${PORT__OP_GETH_P2P:-39393}:${PORT__OP_GETH_P2P:-39393}/tcp
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+
+  op-nethermind:
+    build:
+      context: .
+      dockerfile: docker/dockerfiles/Dockerfile.nethermind
+    restart: unless-stopped
+    stop_grace_period: 5m
+    profiles:
+      - nethermind
+      - !op-geth
+    env_file:
+      - ./envs/${NETWORK_NAME}/nethermind.env
+      - .env
+    volumes:
+      - ./scripts:/scripts:ro
+      - op_nethermind:/nethermind
+      - shared:/shared
+      - torrent_downloads:/downloads
+      - ./.upgrade-pectra:/upgrade-pectra
+    ports:
+      - ${PORT__OP_NETHERMIND_HTTP:-9995}:9995
+      - ${PORT__OP_NETHERMIND_WS:-9996}:9996
+      - ${PORT__OP_NETHERMIND_AUTHRPC:-8551}:8551
+      - ${PORT__OP_NETHERMIND_METRICS:-6062}:6060
+      - ${PORT__OP_NETHERMIND_DISCOVERY:-30303}:30303/udp
+      - ${PORT__OP_NETHERMIND_DISCOVERY:-30303}:30303/tcp
     extra_hosts:
       - "host.docker.internal:host-gateway"
 
@@ -126,4 +157,5 @@ volumes:
   influxdb_data:
   shared:
   op_geth:
+  op_nethermind:
   torrent_downloads:

--- a/docker/dockerfiles/Dockerfile.nethermind
+++ b/docker/dockerfiles/Dockerfile.nethermind
@@ -1,0 +1,11 @@
+FROM nethermind/nethermind:1.31.6
+
+# Install bash
+RUN apt-get update && apt-get install -y bash
+
+# Copy and set up the startup script
+COPY scripts/start-op-nethermind.sh /scripts/
+RUN chmod +x /scripts/start-op-nethermind.sh
+
+# Set the entrypoint to use bash
+ENTRYPOINT ["/bin/bash", "/scripts/start-op-nethermind.sh"] 

--- a/envs/op-sepolia/nethermind.env
+++ b/envs/op-sepolia/nethermind.env
@@ -1,0 +1,12 @@
+NETWORK_NAME=op-sepolia
+BEDROCK_SEQUENCER_HTTP=https://sepolia-sequencer.optimism.io
+NETHERMIND_LOG_LEVEL=Info
+NODE_TYPE=full
+
+# Optional EthStats configuration
+# OP_NETHERMIND_ETHSTATS_ENABLED=true
+# OP_NETHERMIND_ETHSTATS_NODE_NAME=MyNethermindNode
+# OP_NETHERMIND_ETHSTATS_ENDPOINT=ws://stats.optimism.io:3000
+
+# Optional bootnode configuration
+# OP_NETHERMIND_BOOTNODES=enode://...

--- a/scripts/start-op-nethermind.sh
+++ b/scripts/start-op-nethermind.sh
@@ -1,0 +1,76 @@
+#!/bin/bash
+set -e
+
+# Add debug information
+echo "Debug: Checking Nethermind executable..."
+ls -l /nethermind/Nethermind.Runner || echo "Nethermind.Runner not found in /nethermind/"
+echo "Debug: Checking entire /nethermind directory..."
+ls -la /nethermind/ || echo "/nethermind directory not found or empty"
+
+# Wait for the Bedrock flag for this network to be set.
+echo "Waiting for Bedrock node to initialize..."
+while [ ! -f /shared/initialized.txt ]; do
+  sleep 1
+done
+
+if [ ! -f /upgrade-pectra/upgraded ]; then
+  echo "Please upgrade to Pectra with upgrade-pectra.sh"
+  exit 1
+fi
+
+# Default configurations
+NETHERMIND_DATA_DIR=${NETHERMIND_DATA_DIR:-/nethermind}
+NETHERMIND_LOG_LEVEL=${NETHERMIND_LOG_LEVEL:-Info}
+
+# Use environment variables from .env
+RPC_PORT="${PORT__OP_NETHERMIND_HTTP:-8545}"
+WS_PORT="${PORT__OP_NETHERMIND_WS:-8546}"
+AUTHRPC_PORT="${PORT__OP_NETHERMIND_AUTHRPC:-8551}"
+METRICS_PORT="${PORT__OP_NETHERMIND_METRICS:-6060}"
+DISCOVERY_PORT="${PORT__OP_NETHERMIND_DISCOVERY:-30303}"
+
+# Create necessary directories
+mkdir -p "$NETHERMIND_DATA_DIR"
+
+# Additional arguments based on environment variables
+ADDITIONAL_ARGS=""
+
+if [ -n "${OP_NETHERMIND_BOOTNODES:-}" ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --Network.Bootnodes=$OP_NETHERMIND_BOOTNODES"
+fi
+
+if [ -n "${OP_NETHERMIND_ETHSTATS_ENABLED:-}" ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --EthStats.Enabled=$OP_NETHERMIND_ETHSTATS_ENABLED"
+fi
+
+if [ -n "${OP_NETHERMIND_ETHSTATS_ENDPOINT:-}" ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --EthStats.NodeName=${OP_NETHERMIND_ETHSTATS_NODE_NAME:-NethermindNode} --EthStats.Endpoint=$OP_NETHERMIND_ETHSTATS_ENDPOINT"
+fi
+
+# Determine syncmode based on NODE_TYPE
+if [ "$NODE_TYPE" = "full" ]; then
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --Sync.FastSync=true"
+else
+    ADDITIONAL_ARGS="$ADDITIONAL_ARGS --Sync.FastSync=false"
+fi
+
+# Execute Nethermind with properly formatted arguments
+exec /nethermind/Nethermind.Runner \
+    --config "$NETWORK_NAME" \
+    --datadir "$NETHERMIND_DATA_DIR" \
+    --Optimism.SequencerUrl "$BEDROCK_SEQUENCER_HTTP" \
+    --log "$NETHERMIND_LOG_LEVEL" \
+    --JsonRpc.Enabled true \
+    --JsonRpc.Host 0.0.0.0 \
+    --JsonRpc.WebSocketsPort "$WS_PORT" \
+    --JsonRpc.Port "$RPC_PORT" \
+    --JsonRpc.JwtSecretFile /shared/jwt.txt \
+    --JsonRpc.EngineHost 0.0.0.0 \
+    --JsonRpc.EnginePort "$AUTHRPC_PORT" \
+    --JsonRpc.EnabledModules "Web3,Eth,Subscribe,Net,Engine" \
+    --Network.DiscoveryPort "$DISCOVERY_PORT" \
+    --Network.P2PPort "$DISCOVERY_PORT" \
+    --HealthChecks.Enabled true \
+    --Metrics.Enabled true \
+    --Metrics.ExposePort "$METRICS_PORT" \
+    $ADDITIONAL_ARGS

--- a/scripts/start-op-node.sh
+++ b/scripts/start-op-node.sh
@@ -21,7 +21,7 @@ fi
 # Start op-node.
 exec op-node \
   --l1=$OP_NODE__RPC_ENDPOINT \
-  --l2=http://op-geth:8551 \
+  --l2=http://${EXECUTION_CLIENT}:8551 \
   --rpc.addr=0.0.0.0 \
   --rpc.port=9545 \
   --l2.jwt-secret=/shared/jwt.txt \

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Get the execution client from env var or default to op-geth
+CLIENT=${EXECUTION_CLIENT:-op-geth}
+
+# Map the client name to the correct profile
+if [ "$CLIENT" = "nethermind" ]; then
+    PROFILE="nethermind"
+else
+    PROFILE="op-geth"
+fi
+
+# Stop any running containers and remove volumes
+docker compose down -v
+
+# Start with the appropriate profile
+docker compose --profile $PROFILE up -d --build


### PR DESCRIPTION
Add support for using Nethermind as an alternative execution client
alongside op-geth